### PR TITLE
Make erasure of progress bar optional when ending

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,11 @@ cli.progress.update({
 });
 ```
 
+### Keep progress bar visible after it ends
+
+To keep the progress bar visible after it reaches 100%, just pass the value `false` to the 
+`cli.progress.end()` function. This will prevent it from being erased from the screen.
+
 ### Unicode or ASCII
 
 By default the progress bar is rendered using various Unicode characters:

--- a/cli.js
+++ b/cli.js
@@ -546,12 +546,14 @@ var cli = module.exports = {
 			}
 		},
 		
-		end: function() {
+		end: function(erase) {
 			// end of progress session
 			if (!cli.tty()) return;
 			if (!this.running) return;
 			
-			this.erase();
+			if (erase !== false) {
+			  this.erase();
+			}
 			clearTimeout( this.timer );
 			this.running = false;
 			this.args = {};


### PR DESCRIPTION
I would like to keep the progress bar - a unit test progress bar containing passed, failed and skipped sections - on screen after it reaches 100%, as an indicator to the user.
I do want to clean it up, i.e. call progress.end(), but with the option of not erasing the latest drawn progress bar. I've currently implemented it with a strict check for a boolean of type false, i.e. no falsy
support.